### PR TITLE
Update README.md - fixed typo in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ python3 demos_score_FR.py --ref_path sample_images/churchandcapitol.bmp --dist_p
 ### Obtaining CONTRIQUE Features
 For calculating CONTRIQUE features, the following commands can be used. The features are saved in '.npy' format.
 ```
-python3 demo_feat.py --im_path sample_images/60.bmp --model_path models/CONTRIQUE_checkpoint25.tar --features_save_path features.npy
-python3 demo_feat.py --im_path sample_images/img66.bmp --model_path models/CONTRIQUE_checkpoint25.tar --features_save_path features.npy
+python3 demo_feat.py --im_path sample_images/60.bmp --model_path models/CONTRIQUE_checkpoint25.tar --feature_save_path features.npy
+python3 demo_feat.py --im_path sample_images/img66.bmp --model_path models/CONTRIQUE_checkpoint25.tar --feature_save_path features.npy
 ```
 
 ## Training CONTRIQUE


### PR DESCRIPTION
Hey Pavan, thanks for the great codebase. I noticed this typo in the command for generating features - I believe the argument should be `--feature_save_path`, not `--features_save_path`. Could you please verify and amend if this seems correct?